### PR TITLE
Update src path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 ._*
 
 ngrok
+*.swp

--- a/index.js
+++ b/index.js
@@ -66,9 +66,10 @@ app.use(
     outputStyle: "compressed"
   })
 );
+
 app.use(
   postcssMiddleware({
-    src: req => path.join("./", req.path),
+    src: req => path.join(`${__dirname}public`, req.url),
     plugins: [
       autoprefixer({
         browsers: ["> 1%", "IE 7"],
@@ -77,6 +78,7 @@ app.use(
     ]
   })
 );
+
 app.use(express.static("public"));
 app.use("/", appRoutes);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,7 +2356,7 @@ es6-iterator@^2.0.1, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promise@^4.0.3:
+es6-promise@^4.0.3, es6-promise@^4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
   integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
@@ -2367,10 +2367,6 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
-
-es6-promise@^4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
@@ -3520,7 +3516,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6033,16 +6029,11 @@ pug@^2.0.3:
 punycode@>=0.2.0, punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
-
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@6.5.1:
   version "6.5.1"
@@ -6365,7 +6356,7 @@ request@2.87.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.87.0:
+request@^2.53.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==


### PR DESCRIPTION
Nos meus testes aqui, estava tentando configurar o graphql na aplicação, e como gosto de deixar separados as coisas em pastas tinha criado uma pasta chamada graphql na estrutura do projeto. 
O que me ocasionou um problema quando criava a rota por exemplo:

`````
router.use("/graphql", (req, res) => {
  res.send("graphql endpoint");
});
`````
Devido a existência do diretório não tinha sucesso quando tentava renderizar a rota. Fiz o teste e isso replicava para qualquer outra string e pasta criada no projeto. Isso estava implicando por exemplo se precisa-se criar uma rota com o endpoint /models ia acontecer problemas. 

Investigando mais a fundo descobri que o middleware usado para processar o css estava causando a interferência, olhei a documentação em https://github.com/sass/node-sass-middlewar e vi que precisava ajustar o src do postcssMiddleware e fiz o ajuste de acordo com a modificação. Resolvendo o problema.