### PR TITLE
chore: transfer xp

### DIFF
--- a/components/users/usersController.js
+++ b/components/users/usersController.js
@@ -196,7 +196,7 @@ const transferScore = async (userId, type, score) => {
     if (type === 'slack') {
       user = await service.transferScoreToSlackUser(userId, score)
     } else if (type === 'rocket') {
-      user = await service.transferScoreToSlackUser(userId, score)
+      user = await service.transferScoreToRocketUser(userId, score)
     }
   } catch (e) {
     errors._throw(file, 'transferScore', e)


### PR DESCRIPTION
- Corrigido nome da função `transferScoreToRocketUser`

- Adicionado mais uma condição para buscar usuarios `$ne: null`, pois estavam sendo retornados users com o rocketId || userId === null

- Adicionado interação para usuarios do rocket que recebem pontos, assim a gente evita direrencas entre a pontuação do ranking e pontuação atual

Ainda temos um bug onde o usuario com rocketId atualizado nao é retornado para o frontend. A pontuação e interação estão sendo atualizadas/criadas com sucesso, então o bug nao afeta o resultado esperado. Esse eu nao consegui corrigir. 
