### PR TITLE
dev to master

### DIFF
--- a/components/achievementsLevel/achievementsLevelService.js
+++ b/components/achievementsLevel/achievementsLevelService.js
@@ -39,7 +39,7 @@ const sendEarnedMessage = async user => {
   if (!user.username) return
 
   await sendMessageToUser(user)
-  await sendMessageToRoom(user)
+  // await sendMessageToRoom(user)
 }
 
 const sendMessageToUser = async user => {

--- a/components/commands/commandsService.js
+++ b/components/commands/commandsService.js
@@ -22,8 +22,8 @@ const getCommandMessage = async message => {
     response = await commandsList(message)
   } else if (regex.sendPoints.test(message.msg)) {
     response = users.sendPoints(message)
-  } else if (regex.checkPro.test(message.msg)) {
-    response = await users.commandUserIsPro(message)
+  } else if (regex.checkInfos.test(message.msg)) {
+    response = await users.commandUserInfos(message)
   } else if (regex.openSourceRemoveRepositoryUser.test(message.msg)) {
     response = await github.removeRepositoryUser(message)
   } else if (regex.openSource.test(message.msg)) {

--- a/components/commands/commandsUtils.js
+++ b/components/commands/commandsUtils.js
@@ -47,7 +47,7 @@ const getCommandsRegex = () => {
 }
 
 const getUsernameByMessage = message => {
-  const checkFields = /(@[a-z-]+)/g
+  const checkFields = /(@[a-z0-9\-]+)/g
   const result = checkFields.exec(message)
   return result ? result[1].replace('@', '') : false
 }

--- a/components/commands/commandsUtils.js
+++ b/components/commands/commandsUtils.js
@@ -25,7 +25,7 @@ const getCoreTeamCommandsText = () => {
       text: `Digite ${'`!darpontos`'} ${'`@nome-usuario`'} ${'`pontos`'} ${'`motivo`'} para dar pontos ao usuário. `
     },
     {
-      text: `Digite ${'`!checkpro`'} ${'`@nome-usuario`'} para checar se o usuario é Pro e a duração do beneficio. `
+      text: `Digite ${'`!checkinfos`'} ${'`@nome-usuario`'} para checar dados relevantes do usuário. `
     }
   ]
 }
@@ -39,7 +39,7 @@ const getCommandsRegex = () => {
     isPro: /^!pro$/g,
     commands: /^!comandos$/g,
     sendPoints: /^!darpontos/g,
-    checkPro: /^!checkpro/g,
+    checkInfos: /^!checkinfos/g,
     openSource: /^!opensource$/g,
     openSourceAddRepository: /^!addrepositorio[ \d\w]*$/g,
     openSourceRemoveRepositoryUser: /^!removerepositoriousuario[ \d\w @a-z-A-Z]*$/g

--- a/components/linkedin/linkedinController.js
+++ b/components/linkedin/linkedinController.js
@@ -32,7 +32,7 @@ const auth = async code => {
     return { token }
   } catch (e) {
     errors._throw(file, 'auth', e)
-    return { error: 'Erro ao acessar linkedin auth' }
+    return { error: e }
   }
 }
 

--- a/components/users/usersController.js
+++ b/components/users/usersController.js
@@ -119,7 +119,7 @@ const commandPro = async message => {
   return response
 }
 
-const commandUserIsPro = async message => {
+const commandUserInfos = async message => {
   const coreTeam = await isCoreTeam(message.u._id)
   if (!coreTeam) return { msg: 'Ops! *Não tens acesso* a esta operação!' }
 
@@ -128,8 +128,6 @@ const commandUserIsPro = async message => {
 
   const user = await dal.findOne({ username: username })
   if (!user) return { msg: 'Usuário *não* encontrado.' }
-
-  if (!user.pro) return { msg: 'Usuário *não possui* plano pro!' }
 
   const beginDate = user.proBeginAt
     ? moment(user.proBeginAt).format('L')
@@ -140,10 +138,19 @@ const commandUserIsPro = async message => {
     : 'Sem data definida'
 
   return {
-    msg: 'Usuário *possui* plano pro!',
+    msg: `*Usuário*: _${user.name}_`,
     attachments: [
       {
-        text: `Plano iniciou em ${beginDate} e terminará em ${finishDate}`
+        text: `*Nível*: ${user.level}`
+      },
+      {
+        text: `*XP*: ${user.score}`
+      },
+      {
+        text: user.pro
+          ? `Usuário *possui* plano pro.\n\
+          Plano iniciou em *${beginDate}* e terminará em *${finishDate}*`
+          : 'Usuário *não possui* plano pro!'
       }
     ]
   }
@@ -229,7 +236,7 @@ export default {
   commandPro,
   findAllToRanking,
   isCoreTeam,
-  commandUserIsPro,
+  commandUserInfos,
   sendWelcomeMessage,
   receiveProPlan,
   getProBeginDate,

--- a/components/users/usersUtils.js
+++ b/components/users/usersUtils.js
@@ -32,7 +32,7 @@ const getWelcomeMessage = () => {
 
 const getSendedPointsOptions = async message => {
   // eslint-disable-next-line no-useless-escape
-  const regex = /(!darpontos) (@[a-z\-]+) ([\d]+) "(.+?)"/g
+  const regex = /(!darpontos) (@[a-z0-9\-]+) ([\d]+) "(.+?)"/g
   const options = await regex.exec(message)
   return options
 }

--- a/config/xprules.yml
+++ b/config/xprules.yml
@@ -13,7 +13,7 @@ reactions:
     positive: 3
     negative: -1
 github:
-  issue: 1
+  issue: 2
   review: 3
   pull_request: 5
   merged_pull_request: 9


### PR DESCRIPTION
- Mensagens de conquistas não serão enviadas para canais. Apenas para o usuário que a conquistou. Funcionalidade será repensada.

- Comandos que exigem nome de usuário agora processão corretamente usernames que contenham números .

- Criado comando `!checkinfos`, ele agrega as funcionalidades do comando `!checkpro` e tem as mesmas regras de negocio. E ainda mostra level e xp do usuário. 

- Removido comando `!checkpro` pelo motivo citado acima.
