### PR TITLE
Fix/level10+

### DIFF
--- a/components/auth/authRoutes.js
+++ b/components/auth/authRoutes.js
@@ -20,7 +20,7 @@ router.post('/linkedin', async (req, res) => {
     type: 'linkedin',
     code: req.body.code
   })
-  console.log(result)
+
   return result.error ? res.status(500).json(result) : res.json(result)
 })
 

--- a/components/auth/authRoutes.js
+++ b/components/auth/authRoutes.js
@@ -20,6 +20,7 @@ router.post('/linkedin', async (req, res) => {
     type: 'linkedin',
     code: req.body.code
   })
+  console.log(result)
   return result.error ? res.status(500).json(result) : res.json(result)
 })
 

--- a/components/users/usersUtils.js
+++ b/components/users/usersUtils.js
@@ -2,8 +2,13 @@ import config from 'config-yml'
 import commandsUtils from '../commands/commandsUtils'
 import interactionsUtils from '../interactions/interactionsUtils'
 
-const calculateLevel = score =>
-  config.levelrules.levels_range.findIndex(l => score < l) + 1
+const calculateLevel = score => {
+  const levelsRange = config.levelrules.levels_range
+  const lastValue = levelsRange.slice(-1)[0]
+
+  if (score >= lastValue) return 10
+  return levelsRange.findIndex(l => score < l) + 1
+}
 
 const getUsernameByMessage = message => {
   return commandsUtils.getUsernameByMessage(message)


### PR DESCRIPTION
Nosso levelsRange esta assim:
`[ 49, 99, 149, 249, 399, 649, 1049, 1699, 2749, 4450 ]`

O método para buscar o level é assim:
`return levelsRange.findIndex(l => score < l) + 1`

Logo, quando a gente tenta buscar o level de algum usuário com mais de 4450 pontos, a função retorna zero.

Este PR resolve este problema.