### PR TITLE
fix: atena DM

### DIFF
--- a/components/rocket/rocketController.js
+++ b/components/rocket/rocketController.js
@@ -25,6 +25,7 @@ const handle = async (error, message, messageOptions) => {
   }
 
   try {
+    if (messageOptions.roomType === 'd') await commands.handle(message)
     if (!service.isValidMessage(BOT_ID, message, messageOptions)) return
 
     const data = {


### PR DESCRIPTION
Adicionado condicional que verifica se a sala é privada, se a mesma for, o script vai procurar por comandos e executa-los.

Porem temos um pequeno problema.

Este é o corpo da mensagem:

```
{ origin: 'rocket',
  _id: 'FY4XDLkjMHCq2fijt',
  rid: 'JrvXCdYe7xDSLXgzjjCQ6JdnXjhSrgJsr5',
  msg: '!comandos',
  ts: { '$date': 1568058997029 },
  u:
   { _id: 'jCQ6JdnXjhSrgJsr5',
     username: 'julio-goncalves',
     name: 'Julio Gonçalves' },
  _updatedAt: { '$date': 1568058997057 },
  mentions: [],
  channels: [],
  roomParticipant: true,
  roomType: 'd' }
```
Com essas infos  nao tem como saber se o comando foi enviado pra atena ou para outra pessoa. Logo, o comando será executado em qualquer mensagem privada.

Eu consigo resolver isso fazendo uma chamada pra api do rocket e pegando os dados da sala. Mas isso vai resultar em uma requisição a api do rocket pra cada mensagem privada enviada.

O que vcs acham menos ruim? 