### PR TITLE
fix: daily limit

### DIFF
--- a/components/interactions/interactionsController.js
+++ b/components/interactions/interactionsController.js
@@ -12,12 +12,11 @@ const saveManual = data => {
 const handle = async data => {
   moduleController = service.getModuleController(data)
   const interaction = await service.normalize(data, moduleController)
+  const user = await moduleController.findOrCreateUser(interaction)
+  interaction.user = user._id
 
   const countingScore = await service.hasScore(moduleController, interaction)
   if (!countingScore) interaction.score = 0
-
-  const user = await moduleController.findOrCreateUser(interaction)
-  interaction.user = user._id
 
   await service.onSaveInteraction(interaction, user)
 


### PR DESCRIPTION
- A função que define limite diário precisa do _id pra buscar as interações;
- O _id do usuário só estava sendo buscado `após` a execução da função de limite diário;
- A ordem das funções foram redefinidas para o limite diário funcionar corretamente;